### PR TITLE
Support for decoration in `status` log level.

### DIFF
--- a/example/test.dart
+++ b/example/test.dart
@@ -1,9 +1,10 @@
 import 'package:recipe/recipe.dart';
 import 'package:recipe/src/recipe.dart';
+import 'package:recipe/src/utils.dart';
 
 void main() async {
   FrameworkUtils.loggingLevel = LogLevels.verbose;
-  FrameworkUtils.showTimestampInLogs = false;
+  FrameworkUtils.showTimestampInLogs = true;
 
   bake(MyRecipe()).listen(FrameworkUtils.log);
 }
@@ -15,22 +16,24 @@ class MyRecipe extends Recipe {
 
     final baker = Baker.of(context);
 
-    status('Just one recipe.');
+    status('Just one recipe.', status: Statuses.successful);
     yield* baker.bake(RecipeB());
 
-    status('Multiple recipes one by one (sequential)');
+    status('Multiple recipes one by one (sequential)', status: Statuses.failed);
     yield* baker.bake(RecipeB());
     yield* baker.bake(Delayed(RecipeB(), duration: const Duration(seconds: 1)));
     yield* baker.bake(RecipeB());
 
-    status('Multiple recipes in sequential using Baker and BakeStrategy');
+    status('Multiple recipes in sequential using Baker and BakeStrategy',
+        status: Statuses.warning);
     yield* baker.bakeAll([
       RecipeB(),
       Delayed(RecipeB(), duration: const Duration(seconds: 1)),
       RecipeB(),
     ]);
 
-    status('Multiple recipes in parallel using Baker and BakeStrategy');
+    status('Multiple recipes in parallel using Baker and BakeStrategy',
+        status: Statuses.successful);
     yield* baker.bakeAll(
       [
         RecipeB(),

--- a/lib/src/framework_entity.dart
+++ b/lib/src/framework_entity.dart
@@ -29,10 +29,19 @@ mixin EntityLogging on FrameworkEntity {
   static hideHashCodeOfEntities() => _shouldIncludeHash = false;
 
   @protected
-  void log(Object? object, {LogLevel level = LogLevels.info}) {
+  void log(
+    Object? object, {
+    LogLevel level = LogLevels.info,
+    Statuses? status,
+  }) {
     final moduleName = _shouldIncludeHash ? '$name#$hashCode' : name;
 
-    FrameworkUtils.log(object, module: moduleName, level: level);
+    return FrameworkUtils.log(
+      object,
+      module: moduleName,
+      level: level,
+      status: status,
+    );
   }
 
   @protected
@@ -45,7 +54,8 @@ mixin EntityLogging on FrameworkEntity {
   void warn(String message) => log(message, level: LogLevels.warning);
 
   @protected
-  void status(String message) => log(message, level: LogLevels.status);
+  void status(String message, {required Statuses status}) =>
+      log(message, level: LogLevels.status, status: status);
 
   @protected
   void info(String message) => log(message, level: LogLevels.info);


### PR DESCRIPTION
Supported status typed: failed, success, warning

![image](https://user-images.githubusercontent.com/25143503/140322332-95ef0c3b-8cbb-44c6-969e-4e048d8161de.png)
