### PR TITLE
Any typed port

### DIFF
--- a/lib/src/bake_context.dart
+++ b/lib/src/bake_context.dart
@@ -7,7 +7,7 @@ import 'package:recipe/src/recipe.dart' show Recipe;
 import 'package:recipe/src/utils.dart';
 
 @immutable
-class BakeContext<T extends Object> with FrameworkEntity, EntityLogging {
+class BakeContext<T> with FrameworkEntity, EntityLogging {
   @internal
   BakeContext({
     required final Recipe of,

--- a/lib/src/ports/src/connection.dart
+++ b/lib/src/ports/src/connection.dart
@@ -1,7 +1,7 @@
 part of recipe.ports;
 
 @immutable
-abstract class Connection<T extends Object> with FrameworkEntity {
+abstract class Connection<T> with FrameworkEntity {
   @literal
   const Connection({
     required final this.from,
@@ -24,11 +24,9 @@ abstract class Connection<T extends Object> with FrameworkEntity {
   }
 }
 
-mixin _WiredConnectionHandler<T extends Object> on Connection<T> {}
-mixin _WirelessConnectionHandler<T extends Object> on Connection<T> {}
+mixin _WiredConnectionHandler<T> on Connection<T> {}
+mixin _WirelessConnectionHandler<T> on Connection<T> {}
 
-class WiredConnection<T extends Object> = Connection<T>
-    with _WiredConnectionHandler;
+class WiredConnection<T> = Connection<T> with _WiredConnectionHandler<T>;
 
-class WirelessConnection<T extends Object> = Connection<T>
-    with _WirelessConnectionHandler<T>;
+class WirelessConnection<T> = Connection<T> with _WirelessConnectionHandler<T>;

--- a/lib/src/ports/src/input_port.dart
+++ b/lib/src/ports/src/input_port.dart
@@ -1,6 +1,6 @@
 part of recipe.ports;
 
-abstract class InputPort<T extends Object> extends Port<T> {
+abstract class InputPort<T> extends Port<T> {
   InputPort(final String name) : super(name);
 
   @useResult
@@ -23,7 +23,7 @@ abstract class InputPort<T extends Object> extends Port<T> {
   }
 }
 
-mixin _SingleInboundInputPortHandler<T extends Object> on InputPort<T> {
+mixin _SingleInboundInputPortHandler<T> on InputPort<T> {
   @nonVirtual
   Connection<T>? inboundConnection;
 
@@ -58,7 +58,7 @@ mixin _SingleInboundInputPortHandler<T extends Object> on InputPort<T> {
   }
 }
 
-mixin _MultiInboundInputPortHandler<T extends Object> on InputPort<T> {
+mixin _MultiInboundInputPortHandler<T> on InputPort<T> {
   @override
   UnmodifiableSetView<Connection<T>> get connections =>
       UnmodifiableSetView(inboundConnections);
@@ -81,8 +81,8 @@ mixin _MultiInboundInputPortHandler<T extends Object> on InputPort<T> {
   }
 }
 
-class SingleInboundInputPort<T extends Object> = InputPort<T>
+class SingleInboundInputPort<T> = InputPort<T>
     with _SingleInboundInputPortHandler<T>;
 
-class MultiInboundInputPort<T extends Object> = InputPort<T>
+class MultiInboundInputPort<T> = InputPort<T>
     with _MultiInboundInputPortHandler<T>;

--- a/lib/src/ports/src/output_port.dart
+++ b/lib/src/ports/src/output_port.dart
@@ -1,6 +1,6 @@
 part of recipe.ports;
 
-class OutputPort<T extends Object> extends Port<T> {
+class OutputPort<T> extends Port<T> {
   OutputPort(final String name) : super(name);
 
   @override

--- a/lib/src/ports/src/port_base.dart
+++ b/lib/src/ports/src/port_base.dart
@@ -1,6 +1,6 @@
 part of recipe.ports;
 
-abstract class Port<T extends Object> with FrameworkEntity {
+abstract class Port<T> with FrameworkEntity {
   const Port(this.name);
 
   @override

--- a/lib/src/recipe.dart
+++ b/lib/src/recipe.dart
@@ -8,8 +8,7 @@ import 'package:recipe/src/framework_entity.dart';
 import 'package:recipe/src/ports/ports.dart';
 import 'package:recipe/src/utils.dart';
 
-abstract class Recipe<I extends Object, O extends Object>
-    with FrameworkEntity, EntityLogging {
+abstract class Recipe<I, O> with FrameworkEntity, EntityLogging {
   Recipe({
     required final this.inputPort,
     required final this.outputPort,


### PR DESCRIPTION
Removes bounds on generic type `T` for `Port`s and other relevant places.

**Pros:**
- Allows `null` to be written if needed
- Linter lints about not having explicit type arguments.


**Cons:**
_Nothing so far_